### PR TITLE
fix: Update deprecated service name of Databus

### DIFF
--- a/src/solution/my_edge_app/data-analytics/program/data_analytics.py
+++ b/src/solution/my_edge_app/data-analytics/program/data_analytics.py
@@ -15,7 +15,7 @@ import logging
 import statistics
 import json
 
-BROKER_ADDRESS='ie_databus'
+BROKER_ADDRESS='ie-databus'
 BROKER_PORT=1883
 MICRO_SERVICE_NAME = 'data-analytics'
 """ Broker user and password for authtentification"""


### PR DESCRIPTION
Changed the databus service name to "ie-databus". The "ie_databus" is now deprecated.

Fixes #4